### PR TITLE
fix: supports non-ASCII filenames on Windows

### DIFF
--- a/mkvmuxer/mkvwriter.cc
+++ b/mkvmuxer/mkvwriter.cc
@@ -12,6 +12,7 @@
 
 #ifdef _MSC_VER
 #include <share.h>  // for _SH_DENYWR
+#include <windows.h>
 #endif
 
 namespace mkvmuxer {
@@ -45,7 +46,21 @@ bool MkvWriter::Open(const char* filename) {
     return false;
 
 #ifdef _MSC_VER
-  file_ = _fsopen(filename, "wb", _SH_DENYWR);
+  int nChar;
+  WCHAR *zWideFilename;
+ 
+  nChar = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+  zWideFilename = (WCHAR*)malloc( nChar*sizeof(zWideFilename[0]) );
+  if( zWideFilename==0 ){
+    return 0;
+  }
+  nChar = MultiByteToWideChar(CP_UTF8, 0, filename, -1, zWideFilename, nChar);
+  if( nChar==0 ){
+    free(zWideFilename);
+    zWideFilename = 0;
+  }
+  file_ = _wfsopen(zWideFilename, L"wb", _SH_DENYWR);
+  free(zWideFilename);
 #else
   file_ = fopen(filename, "wb");
 #endif

--- a/mkvparser/mkvreader.cc
+++ b/mkvparser/mkvreader.cc
@@ -7,6 +7,10 @@
 // be found in the AUTHORS file in the root of the source tree.
 #include "mkvparser/mkvreader.h"
 
+#ifdef _MSC_VER
+#include <windows.h>
+#endif
+
 #include <sys/types.h>
 
 #include <cassert>
@@ -33,7 +37,23 @@ int MkvReader::Open(const char* fileName) {
     return -1;
 
 #ifdef _MSC_VER
-  const errno_t e = fopen_s(&m_file, fileName, "rb");
+  int nChar;
+  WCHAR *zWideFilename;
+ 
+  nChar = MultiByteToWideChar(CP_UTF8, 0, fileName, -1, NULL, 0);
+  zWideFilename = (WCHAR*)malloc( nChar*sizeof(zWideFilename[0]) );
+  if( zWideFilename==0 ){
+    return 0;
+  }
+  nChar = MultiByteToWideChar(CP_UTF8, 0, fileName, -1, zWideFilename, nChar);
+  if( nChar==0 ){
+    free(zWideFilename);
+    zWideFilename = 0;
+  }
+
+
+  const errno_t e = _wfopen_s(&m_file, zWideFilename, L"rb");
+  free(zWideFilename);
 
   if (e)
     return -1;  // error


### PR DESCRIPTION
Files with non-ASCII file names cannot be opened under Windows